### PR TITLE
Add named errors instead of string for handling

### DIFF
--- a/cropster.gemspec
+++ b/cropster.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "typhoeus"
+  
+  spec.add_development_dependency "typhoeus", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -1,5 +1,4 @@
 require 'typhoeus'
-
 require 'cropster/response/response_handler'
 
 module Cropster
@@ -21,7 +20,7 @@ module Cropster
 
     def green_lots(opts={})
       response = request(base_url(opts.merge({processingStep: 'coffee.green'})))
-      raise "There was a problem, code: #{response.code}" unless response.code == 200
+      raise ServiceUnavailableError unless response.code == 200
       Cropster::Response::ResponseHandler.new.green_lots(JSON.parse(response.body))
     end
 
@@ -35,7 +34,7 @@ module Cropster
 
     def roast_batches(opts={})
       response = request(base_url(opts.merge({processingStep: 'coffee.roasting'})))
-      raise "There was a problem, code: #{response.code}" unless response.code == 200
+      raise ServiceUnavailableError unless response.code == 200
       Cropster::Response::ResponseHandler.new.roast_batches(JSON.parse(response.body))
     end
 

--- a/lib/cropster/response/response_handler.rb
+++ b/lib/cropster/response/response_handler.rb
@@ -5,10 +5,10 @@ module Cropster::Response
     require 'cropster/response/roast_batch'
 
     attr_accessor :data_set
-    attr_accessor :compliled_data
+    attr_accessor :compiled_data
 
     def initialize
-      @compliled_data = []
+      @compiled_data = []
     end
 
     def green_lots(data_set)
@@ -25,10 +25,10 @@ module Cropster::Response
       model = Object.const_get("Cropster::Response::" + model)
 
       data_set.each do |data|
-        @compliled_data << model.new(data) if !data.empty?
+        @compiled_data << model.new(data) if !data.empty?
       end
 
-      @compliled_data
+      @compiled_data
     end
   end
 


### PR DESCRIPTION
For error handling, we can return a `ServiceUnavailableError` from the response if it's not successful.