### PR TITLE
Error class instantiation

### DIFF
--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -3,7 +3,6 @@ require 'cropster/response/response_handler'
 
 module Cropster
   class Client
-    ServiceUnavailableError = Class.new(StandardError)
     attr_reader :client_username, :client_password, :group_code
 
     def initialize opts = {}

--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -3,7 +3,7 @@ require 'cropster/response/response_handler'
 
 module Cropster
   class Client
-
+    ServiceUnavailableError = Class.new(StandardError)
     attr_reader :client_username, :client_password, :group_code
 
     def initialize opts = {}

--- a/lib/cropster/error.rb
+++ b/lib/cropster/error.rb
@@ -1,0 +1,4 @@
+module Cropster
+  module ApiError < StandardError
+  end
+end


### PR DESCRIPTION
This creates the `ServiceUnavailableError` class that's used in the `Cropster::Client` as the custom error class has not been defined anywhere.