### PR TITLE
Instantiate error class within `Cropster::Client`

### DIFF
--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -4,6 +4,7 @@ require 'cropster/response/response_handler'
 module Cropster
   class Client
     attr_reader :client_username, :client_password, :group_code
+    ServiceUnavailableError = Class.new(StandardError)
 
     def initialize opts = {}
       @test_mode       = opts[:test_mode].present?

--- a/lib/cropster/error.rb
+++ b/lib/cropster/error.rb
@@ -1,4 +1,0 @@
-module Cropster
-  module ApiError < StandardError
-  end
-end


### PR DESCRIPTION
Incorrectly set up `ServiceUnavailableError` class in #3. This fixes that issue and is a little cleaner.