### PR TITLE
Api v2 prep

### DIFF
--- a/cropster.gemspec
+++ b/cropster.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "typhoeus"
   
-  spec.add_development_dependency "typhoeus", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -14,28 +14,26 @@ module Cropster
       @group_code      = opts[:group_code]
     end
 
-    def base_url(opts)
-      "#{host}#{@api_path}/lot?groupCode=#{@group_code}&#{uri_options(opts)}"
-    end
-
     def green_lots(opts={})
-      response = request(base_url(opts.merge({processingStep: 'coffee.green'})))
-      raise ServiceUnavailableError unless response.code == 200
-      Cropster::Response::ResponseHandler.new.green_lots(JSON.parse(response.body))
-    end
-
-    def host
-      @test_mode ? 'https://test.cropster.com' : 'https://c-sar.cropster.com'
-    end
-
-    def request(url)
-      Typhoeus::Request.get(url, userpwd: username_password)
+      options = opts.merge({processingStep: 'coffee.green'})
+      Cropster::Response::ResponseHandler.new.green_lots( get('lot', options) )
     end
 
     def roast_batches(opts={})
-      response = request(base_url(opts.merge({processingStep: 'coffee.roasting'})))
+      options = opts.merge({processingStep:'coffee.roasting'})
+      Cropster::Response::ResponseHandler.new.roast_batches( get('lot', options) )
+    end
+
+    def get(path, opts={})
+      url = "#{host}#{@api_path}/#{path}?#{uri_options( opts.merge('groupCode' => @group_code) )}"
+      response = Typhoeus::Request.get(url, userpwd: username_password)
       raise ServiceUnavailableError unless response.code == 200
-      Cropster::Response::ResponseHandler.new.roast_batches(JSON.parse(response.body))
+      JSON.parse(response.body)
+    end
+
+    private
+    def host
+      @test_mode ? 'https://test.cropster.com' : 'https://c-sar.cropster.com'
     end
 
     def uri_options(opts)


### PR DESCRIPTION
Cropster is working on v2 of their API.  The updates allow you to set the path of the request.  This will be needed when v2 is released.  I don't have any more info right now, but we're using it to pull profile information.

````rb
cropster_client = Cropster::Client.new(
  :client_username => ENV['CROPSTER_USERNAME'],
  :client_password => ENV['CROPSTER_PASSWORD'],
  :group_code => ENV['CROPSTER_GROUP_CODE'],
  api_path: '/api/rest/v2'
)
cropster_client.get("processing/#{lot_ids.join(',')}")
````