### PR TITLE
Change params to reflect Cropster naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ And then execute:
 Or install it yourself as:
 
     $ gem install cropster
-    
+
 Setup Initializer
 
     CropsterClient = Cropster::Client.new(
-                  :client_username => ENV['CROPSTER_USERNAME'], 
-                  :client_password => ENV['CROPSTER_PASSWORD'],
+                  :client_api_key => ENV['CROPSTER_API_KEY'],
+                  :client_api_secret => ENV['CROPSTER_API_SECRET'],
                   :group_code => ENV['CROPSTER_GROUP_CODE'])
-                  
+
 
 ## Usage
 
@@ -45,13 +45,13 @@ Setup Initializer
       "creationDate"=>1399306071000,
       "project"=>{"id"=>3293, "name"=>"Iced BC-ICED"},
       "weight"=>{"amount"=>17.086, "unit"=>"BAG69KG"}}]
-      
+
 ###Roasted Lots Request
-    
+
     CropsterClient.roasts
-    
+
 ###Roasted Lots Response
-    
+
     [{"id"=>669245,
       "idTag"=>"PR-10237",
       "name"=>"Costa Rica Vista el Valle Zapote",
@@ -66,7 +66,7 @@ Setup Initializer
       "creationDate"=>1401120213000,
       "project"=>nil,
       "weight"=>{"amount"=>48.0, "unit"=>"LBS"}}]
-      
+
 ###Example Optional Params
     CropsterClient.green_lots({page: 1, perPage: 200, locationId: 55789})
 *perPage max is 200

--- a/lib/cropster/client.rb
+++ b/lib/cropster/client.rb
@@ -3,15 +3,15 @@ require 'cropster/response/response_handler'
 
 module Cropster
   class Client
-    attr_reader :client_username, :client_password, :group_code
+    attr_reader :client_api_key, :client_api_secret, :group_code
     ServiceUnavailableError = Class.new(StandardError)
 
     def initialize opts = {}
-      @test_mode       = opts[:test_mode].present?
-      @api_path        = opts[:api_path].presence || '/api/rest/v1'
-      @client_username = opts[:client_username]
-      @client_password = opts[:client_password]
-      @group_code      = opts[:group_code]
+      @test_mode         = opts[:test_mode].present?
+      @api_path          = opts[:api_path].presence || '/api/rest/v1'
+      @client_api_key    = opts[:client_api_key]
+      @client_api_secret = opts[:client_api_secret]
+      @group_code        = opts[:group_code]
     end
 
     def base_url(opts)
@@ -29,7 +29,7 @@ module Cropster
     end
 
     def request(url)
-      Typhoeus::Request.get(url, userpwd: username_password)
+      Typhoeus::Request.get(url, userpwd: basic_auth)
     end
 
     def roast_batches(opts={})
@@ -42,8 +42,8 @@ module Cropster
       URI.encode(opts.map{|k,v| "#{k}=#{v}"}.join("&"))
     end
 
-    def username_password
-      "#{@client_username}:#{@client_password}"
+    def basic_auth
+      "#{@client_api_key}:#{@client_api_secret}"
     end
   end
 end

--- a/lib/cropster/version.rb
+++ b/lib/cropster/version.rb
@@ -1,3 +1,3 @@
 module Cropster
-  VERSION = "0.0.2"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Cropster users have both a username/password and an api key/secret. When
using the api, we need to authorize using the api key/secret. This
changes the params the client expects to match the naming that Cropster
uses and reduce confusion around authorization.

This is a major version bump because all clients will need to update
their integration to use these changes.